### PR TITLE
Three possible interfaces for tracing

### DIFF
--- a/wit/tracing-exporter.wit
+++ b/wit/tracing-exporter.wit
@@ -1,0 +1,72 @@
+interface observe {
+  use wasi:clocks/wall-clock@0.2.0.{datetime};
+
+  // Emit a given completed read-only-span to the o11y host.
+  emit-span: func(span: read-only-span) -> result<_, string>;
+
+  // get-parent-span-context returns the parent span context of the host.
+  get-parent-span-context: func() -> span-context;
+
+  record read-only-span {
+    // Span name.
+    name: string,
+
+    // Span context.
+    span-context: span-context,
+
+    // Span parent id.
+    parent-span-id: string,
+
+    // Span kind.
+    span-kind: span-kind,
+
+    // Span start time.
+    start-time: datetime,
+
+    // Span end time.
+    end-time: datetime,
+
+    // Span attributes. TODO: Support multiple types
+    attributes: list<tuple<string, string>>,
+
+    // Span resource.
+    otel-resource: otel-resource,
+
+    // TODO: Support dropped_attributes_count, events, links, status, and instrumentation lib
+  }
+
+  // Identifying trace information about a span.
+  record span-context {
+    // Hexidecimal representation of the trace id.
+    trace-id: string,
+
+    // Hexidecimal representation of the span id.
+    span-id: string,
+
+    // Hexidecimal representation of the trace flags
+    trace-flags: string,
+
+    // Span remoteness
+    is-remote: bool,
+
+    // Entirity of tracestate
+    trace-state: string,
+  }
+
+  enum span-kind {
+    client,
+    server,
+    producer,
+    consumer,
+    internal
+  }
+
+  // An immutable representation of the entity producing telemetry as attributes.
+  record otel-resource {
+    // Resource attributes.
+    attrs: list<tuple<string, string>>,
+
+    // Resource schema url.
+    schema-url: option<string>,
+  }
+}

--- a/wit/tracing-processor.wit
+++ b/wit/tracing-processor.wit
@@ -1,0 +1,72 @@
+interface observe {
+  use wasi:clocks/wall-clock@0.2.0.{datetime};
+
+  // Record that a span in the guest has started.
+  on-span-start: func(span-context: span-context);
+
+  // Record that a span in the guest has ended.
+  on-span-end: func(span: read-only-span);
+
+  record read-only-span {
+    // Span name.
+    name: string,
+
+    // Span context.
+    span-context: span-context,
+
+    // Span parent id.
+    parent-span-id: string,
+
+    // Span kind.
+    span-kind: span-kind,
+
+    // Span start time.
+    start-time: datetime,
+
+    // Span end time.
+    end-time: datetime,
+
+    // Span attributes. TODO: Support multiple types
+    attributes: list<tuple<string, string>>,
+
+    // Span resource.
+    otel-resource: otel-resource,
+
+    // TODO: Support dropped_attributes_count, events, links, status, and instrumentation lib
+  }
+
+  // Identifying trace information about a span.
+  record span-context {
+    // Hexidecimal representation of the trace id.
+    trace-id: string,
+
+    // Hexidecimal representation of the span id.
+    span-id: string,
+
+    // Hexidecimal representation of the trace flags
+    trace-flags: string,
+
+    // Span remoteness
+    is-remote: bool,
+
+    // Entirity of tracestate
+    trace-state: string,
+  }
+
+  enum span-kind {
+    client,
+    server,
+    producer,
+    consumer,
+    internal
+  }
+
+  // An immutable representation of the entity producing telemetry as attributes.
+  record otel-resource {
+    // Resource attributes.
+    attrs: list<tuple<string, string>>,
+
+    // Resource schema url.
+    schema-url: option<string>,
+  }
+}

--- a/wit/tracing-span.wit
+++ b/wit/tracing-span.wit
@@ -1,0 +1,14 @@
+interface observe {
+  resource span {
+    // enter returns a new span with the given name.
+    enter: static func(name: string) -> span;
+
+    // set-attribute sets an attribute on the span.
+    set-attribute: func(key: string, value: string);
+
+    // TODO: Eventually other methods for submitting events etc.
+
+    // close closes the span.
+    close: func();
+  }
+}


### PR DESCRIPTION
## Summary & Context

Inspired by @endocrimes work with #12 I've spent a lot of time prototyping what a host implementation for the tracing part of WASI Observe would look like. In my experimenting I've encountered three reasonable WIT interfaces that we could use[^1]. Below you'll find details on each of the three interfaces. Working examples of these interfaces can be found at [calebschoepp/opentelemetry-wasi](https://github.com/calebschoepp/opentelemetry-wasi)[^2].

The WIT provided in this PR is not complete. It is missing functionality, likely has syntax errors, and is riddled with TODOs. The purpose of this PR is not to gather feedback on the specifics of the WIT (though a time will come for that), but rather to collectively decide which interfaces we want to standardize around and use. This PR also provides something concrete for OTel vendors to look at. My hope is that after some discussion on this PR we will have a direction to aim in for the tracing portion of WASI Observe. Then we can go and clean up the WIT and prototype host implementations.

## Interface 1: Exporter

This interface matches the [OTel span exporter interface](https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-exporter). Working examples of this interface can be found [here](https://github.com/calebschoepp/opentelemetry-wasi/tree/main/examples/exporter).

In the language of #12 this interface is acting as a tracing sink. The guest does all the work to create and finish the spans and the host merely acts as a sink for the completed spans.

`get-parent-span-context()` is used in the guest to propagate the trace context from the host to the guest. This allows the guest root span to set its parent span to be the innermost host span.

### Pros
 - The WIT interface is very straightforward.
 - The host implementation is very straightforward.
 - The interface is entirely agnostic to how you record and create your spans in the guest.

### Cons
- No real way to transparently integrate with existing ecosystem. For example in the Rust ecosystem it wouldn't make sense to modify [`opentelemetry-otlp`](https://docs.rs/opentelemetry-otlp/0.16.0/opentelemetry_otlp/) to use this WIT interface when compiled to a WASI target. We would have no way to guarantee that the host implementation is actually using OTLP. Instead language ecosystems would have to create new `WasiExporter` libraries.
- There is no way [^3] to maintain correct parent child relationships between spans when the guest makes a call back into the host e.g. using WASI KeyValue. The host has no way of tracking what span the guest is currently in.
<img width="1509" alt="image" src="https://github.com/WebAssembly/wasi-observe/assets/20216739/d7abec96-1fa2-4144-b581-7f769508bddd">

## Interface 2: Processor

This interface matches the [OTel span processor interface](https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-processor). Working examples of this interface can be found [here](https://github.com/calebschoepp/opentelemetry-wasi/tree/main/examples/processor).

In the language of #12 this interface is acting as a tracing provider. The host actively tracks the spans on the guests behalf and the guest controls it through the WIT boundary.

### Pros
- The WIT interface is very straightforward.
- Span parent child relationships are correctly tracked across both host -> guest and guest -> host boundaries.

### Cons
- The host implementation is complex.
- No real way to transparently integrate with existing ecosystem. For example it wouldn't make sense to have a simple or batch processor transparently send spans to the host. Instead language ecosystems would have to create a new `WasiProcessor` interface.
- Not a very convenient interface to consume directly.
- Works incorrectly if the guest doesn't call `on-span-start` when the span is actually starting. [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.24.0/tracing_opentelemetry/) is an example from the Rust ecosystem that breaks this invariant. It ends up calling both start and end right at the end of the span lifetime and then rewriting the time of the span. For normal OTel libraries this works, but this doesn't work when the host is expecting to track the span.

## Interface 3: Span

This interface matches the [OTel span interface](https://opentelemetry.io/docs/specs/otel/trace/api/#span). Working examples of this interface can be found [here](https://github.com/calebschoepp/opentelemetry-wasi/tree/main/examples/span).

In the language of #12 this interface is acting as a tracing provider. The host actively tracks the spans on the guests behalf and the guest controls it through the WIT boundary.

### Pros
- This interface likely provides the best route to transparently integrate with the existing ecosystem.
- Using a resource is a convenient interface to directly consume e.g. writing a simple component that wants to emit a span or two without pulling in all OTel dependencies.

### Cons
- The host implementation is complex.
- Works incorrectly if the guest doesn't call `enter` when the span is actually starting. [`tracing-opentelemetry`](https://docs.rs/tracing-opentelemetry/0.24.0/tracing_opentelemetry/) is an example from the Rust ecosystem that breaks this invariant. It ends up calling both start and end right at the end of the span lifetime and then rewriting the time of the span. For normal OTel libraries this works, but this doesn't work when the host is expecting to track the span.

[^1]: The interfaces are not mutually exclusive. We could decide that we want to support multiple of these interfaces.
[^2]: The host implementation in these working examples is written for [Spin](https://github.com/fermyon/spin) b/c that is what I'm familiar with.
[^3]: At least that I've been able to come up with. Theoretically you could have the guest provide an export that declares what span it currently is in, but I went down this path and I could not make an implementation work in the host.